### PR TITLE
Correct readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Add the following to your SBT build:
 ```scala
 resolvers += Resolver.bintrayRepo("hmrc", "releases")
 
-libraryDependencies += "uk.gov.hmrc" % "crypto" % "[INSERT-VERSION]"
+libraryDependencies += "uk.gov.hmrc" %% "crypto" % "[INSERT-VERSION]"
 ```
 
 ## License ##


### PR DESCRIPTION
You need two percentage signs to pick up the correct Scala version of the artefact. With just one you will get an unresolved dependency errors at build time.