### PR TITLE
Dc 889

### DIFF
--- a/src/main/scala/uk/gov/hmrc/crypto/ApplicationCrypto.scala
+++ b/src/main/scala/uk/gov/hmrc/crypto/ApplicationCrypto.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 HM Revenue & Customs
+ * Copyright 2017 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,15 +16,21 @@
 
 package uk.gov.hmrc.crypto
 
-object ApplicationCrypto {
+import javax.inject.Inject
 
-  private def sessionCookieCrypto = CryptoGCMWithKeysFromConfig(baseConfigKey = "cookie.encryption")
+import play.api.{Configuration, Play}
 
-  private def ssoPayloadCrypto = CryptoWithKeysFromConfig(baseConfigKey = "sso.encryption")
+trait ApplicationCrypto {
 
-  private def queryParameterCrypto = CryptoWithKeysFromConfig(baseConfigKey = "queryParameter.encryption")
+  val configuration: Configuration
 
-  private def jsonCrypto = CryptoWithKeysFromConfig(baseConfigKey = "json.encryption")
+  private def sessionCookieCrypto = CryptoGCMWithKeysFromConfig(baseConfigKey = "cookie.encryption", () => configuration)
+
+  private def ssoPayloadCrypto = CryptoWithKeysFromConfig(baseConfigKey = "sso.encryption", () => configuration)
+
+  private def queryParameterCrypto = CryptoWithKeysFromConfig(baseConfigKey = "queryParameter.encryption", () => configuration)
+
+  private def jsonCrypto = CryptoWithKeysFromConfig(baseConfigKey = "json.encryption", () => configuration)
 
   lazy val SessionCookieCrypto = sessionCookieCrypto
   lazy val SsoPayloadCrypto = ssoPayloadCrypto
@@ -40,4 +46,12 @@ object ApplicationCrypto {
   def verifyJsonConfiguration() {
     jsonCrypto
   }
+}
+
+object ApplicationCrypto extends ApplicationCrypto {
+  override val configuration: Configuration = Play.current.configuration
+}
+
+class ApplicationCryptoDI @Inject()(config: Configuration) extends ApplicationCrypto {
+  override val configuration: Configuration = config
 }

--- a/src/main/scala/uk/gov/hmrc/crypto/ApplicationCrypto.scala
+++ b/src/main/scala/uk/gov/hmrc/crypto/ApplicationCrypto.scala
@@ -22,15 +22,15 @@ import play.api.{Configuration, Play}
 
 trait ApplicationCrypto {
 
-  val configuration: Configuration
+  implicit val configuration: Configuration
 
-  private def sessionCookieCrypto = CryptoGCMWithKeysFromConfig(baseConfigKey = "cookie.encryption", () => configuration)
+  private def sessionCookieCrypto = CryptoGCMWithKeysFromConfig(baseConfigKey = "cookie.encryption")
 
-  private def ssoPayloadCrypto = CryptoWithKeysFromConfig(baseConfigKey = "sso.encryption", () => configuration)
+  private def ssoPayloadCrypto = CryptoWithKeysFromConfig(baseConfigKey = "sso.encryption")
 
-  private def queryParameterCrypto = CryptoWithKeysFromConfig(baseConfigKey = "queryParameter.encryption", () => configuration)
+  private def queryParameterCrypto = CryptoWithKeysFromConfig(baseConfigKey = "queryParameter.encryption")
 
-  private def jsonCrypto = CryptoWithKeysFromConfig(baseConfigKey = "json.encryption", () => configuration)
+  private def jsonCrypto = CryptoWithKeysFromConfig(baseConfigKey = "json.encryption")
 
   lazy val SessionCookieCrypto = sessionCookieCrypto
   lazy val SsoPayloadCrypto = ssoPayloadCrypto
@@ -49,9 +49,9 @@ trait ApplicationCrypto {
 }
 
 object ApplicationCrypto extends ApplicationCrypto {
-  override val configuration: Configuration = Play.current.configuration
+  implicit val configuration: Configuration = Play.current.configuration
 }
 
 class ApplicationCryptoDI @Inject()(config: Configuration) extends ApplicationCrypto {
-  override val configuration: Configuration = config
+  implicit val configuration: Configuration = config
 }

--- a/src/main/scala/uk/gov/hmrc/crypto/CompositeOneWayCypto.scala
+++ b/src/main/scala/uk/gov/hmrc/crypto/CompositeOneWayCypto.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 HM Revenue & Customs
+ * Copyright 2017 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/crypto/CompositeSymmetricCrypto.scala
+++ b/src/main/scala/uk/gov/hmrc/crypto/CompositeSymmetricCrypto.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 HM Revenue & Customs
+ * Copyright 2017 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/crypto/CryptoGCMWithKeysFromConfig.scala
+++ b/src/main/scala/uk/gov/hmrc/crypto/CryptoGCMWithKeysFromConfig.scala
@@ -23,7 +23,7 @@ trait KeysFromConfigGCM {
 
   val baseConfigKey: String
 
-  val configuration: () => Configuration = () => Play.current.configuration
+  implicit val configuration: () => Configuration
 
   override protected val currentCrypto = {
     val configKey = baseConfigKey + ".key"
@@ -58,4 +58,4 @@ trait KeysFromConfigGCM {
   }
 }
 
-case class CryptoGCMWithKeysFromConfig(baseConfigKey: String, override val configuration: () => Configuration) extends CompositeSymmetricCrypto with KeysFromConfigGCM
+case class CryptoGCMWithKeysFromConfig(baseConfigKey: String)(implicit val configuration: () => Configuration =  () => Play.current.configuration) extends CompositeSymmetricCrypto with KeysFromConfigGCM

--- a/src/main/scala/uk/gov/hmrc/crypto/CryptoWithKeysFromConfig.scala
+++ b/src/main/scala/uk/gov/hmrc/crypto/CryptoWithKeysFromConfig.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 HM Revenue & Customs
+ * Copyright 2017 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,16 +16,18 @@
 
 package uk.gov.hmrc.crypto
 
-import play.api.{Logger, Play}
+import play.api.{Configuration, Logger, Play}
 
 trait KeysFromConfig {
   this: CompositeSymmetricCrypto =>
 
   val baseConfigKey: String
 
+  val configuration: () => Configuration = () => Play.current.configuration
+
   override protected val currentCrypto = {
     val configKey = baseConfigKey + ".key"
-    val currentEncryptionKey = Play.current.configuration.getString(configKey).getOrElse {
+    val currentEncryptionKey = configuration().getString(configKey).getOrElse {
       Logger.error(s"Missing required configuration entry: $configKey")
       throw new SecurityException(s"Missing required configuration entry: $configKey")
     }
@@ -34,7 +36,7 @@ trait KeysFromConfig {
 
   override protected val previousCryptos = {
     val configKey = baseConfigKey + ".previousKeys"
-    val previousEncryptionKeys = Play.current.configuration.getStringSeq(configKey).getOrElse(Seq.empty)
+    val previousEncryptionKeys = configuration().getStringSeq(configKey).getOrElse(Seq.empty)
     previousEncryptionKeys.map(aesCrypto)
   }
 
@@ -51,4 +53,4 @@ trait KeysFromConfig {
   }
 }
 
-case class CryptoWithKeysFromConfig(baseConfigKey: String) extends CompositeSymmetricCrypto with KeysFromConfig
+case class CryptoWithKeysFromConfig(baseConfigKey: String, override val configuration: () => Configuration) extends CompositeSymmetricCrypto with KeysFromConfig

--- a/src/main/scala/uk/gov/hmrc/crypto/CryptoWithKeysFromConfig.scala
+++ b/src/main/scala/uk/gov/hmrc/crypto/CryptoWithKeysFromConfig.scala
@@ -23,7 +23,7 @@ trait KeysFromConfig {
 
   val baseConfigKey: String
 
-  val configuration: () => Configuration = () => Play.current.configuration
+  implicit val configuration: () => Configuration
 
   override protected val currentCrypto = {
     val configKey = baseConfigKey + ".key"
@@ -53,4 +53,4 @@ trait KeysFromConfig {
   }
 }
 
-case class CryptoWithKeysFromConfig(baseConfigKey: String, override val configuration: () => Configuration) extends CompositeSymmetricCrypto with KeysFromConfig
+case class CryptoWithKeysFromConfig(baseConfigKey: String)(implicit val configuration: () => Configuration = () => Play.current.configuration) extends CompositeSymmetricCrypto with KeysFromConfig

--- a/src/main/scala/uk/gov/hmrc/crypto/GCMCrypto.scala
+++ b/src/main/scala/uk/gov/hmrc/crypto/GCMCrypto.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 HM Revenue & Customs
+ * Copyright 2017 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/crypto/OneWayCryptoFromConfig.scala
+++ b/src/main/scala/uk/gov/hmrc/crypto/OneWayCryptoFromConfig.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 HM Revenue & Customs
+ * Copyright 2017 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/crypto/RSAEncryptDecrypt.scala
+++ b/src/main/scala/uk/gov/hmrc/crypto/RSAEncryptDecrypt.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 HM Revenue & Customs
+ * Copyright 2017 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/crypto/SymmetricHasher.scala
+++ b/src/main/scala/uk/gov/hmrc/crypto/SymmetricHasher.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 HM Revenue & Customs
+ * Copyright 2017 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/crypto/crypto.scala
+++ b/src/main/scala/uk/gov/hmrc/crypto/crypto.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 HM Revenue & Customs
+ * Copyright 2017 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/crypto/CryptoGCMWithKeysFromConfigSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/crypto/CryptoGCMWithKeysFromConfigSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 HM Revenue & Customs
+ * Copyright 2017 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -70,7 +70,7 @@ class CryptoGCMWithKeysFromConfigSpec extends WordSpecLike with Matchers with Op
     ))
 
     "return a properly initialised, functional AuthenticatedEncryption object that works with the current key only" in running(fakeApplicationWithCurrentKeyOnly)  {
-      val crypto = CryptoGCMWithKeysFromConfig(baseConfigKey)
+      val crypto = CryptoGCMWithKeysFromConfig(baseConfigKey, () => fakeApplicationWithCurrentKeyOnly.configuration)
 
       crypto.decrypt(crypto.encrypt(CurrentKey.plainMessage)) shouldBe CurrentKey.plainMessage
       crypto.decrypt(crypto.encrypt(CurrentKey.plainByteMessage)) shouldBe CurrentKey.plainByteMessageResponse
@@ -91,7 +91,7 @@ class CryptoGCMWithKeysFromConfigSpec extends WordSpecLike with Matchers with Op
     )
 
     "return a properly initialised, functional AuthenticatedEncryption object that works with the current key only" in running(fakeApplicationWithEmptyPreviousKeys)  {
-      val crypto = CryptoGCMWithKeysFromConfig(baseConfigKey)
+      val crypto = CryptoGCMWithKeysFromConfig(baseConfigKey, () => fakeApplicationWithEmptyPreviousKeys.configuration)
 
       crypto.decrypt(crypto.encrypt(CurrentKey.plainMessage)) shouldBe CurrentKey.plainMessage
       crypto.decrypt(crypto.encrypt(CurrentKey.plainByteMessage)) shouldBe CurrentKey.plainByteMessageResponse
@@ -112,7 +112,7 @@ class CryptoGCMWithKeysFromConfigSpec extends WordSpecLike with Matchers with Op
     )
 
     "allows decrypting payloads that were encrypted using previous keys" in running(fakeApplicationWithCurrentAndPreviousKeys)  {
-      val crypto = CryptoGCMWithKeysFromConfig(baseConfigKey)
+      val crypto = CryptoGCMWithKeysFromConfig(baseConfigKey, () => fakeApplicationWithCurrentAndPreviousKeys.configuration)
 
       val previousKey1Crypto = CompositeSymmetricCrypto.aesGCM(PreviousKey1.encryptionKey, Seq.empty)
       val encryptedWithPreviousKey1 = crypto.encrypt(PreviousKey1.plainMessage, previousKey1Crypto)
@@ -135,7 +135,7 @@ class CryptoGCMWithKeysFromConfigSpec extends WordSpecLike with Matchers with Op
 
     "throw a SecurityException on construction" in running(fakeApplicationWithoutAnyKeys) {
       intercept[SecurityException]{
-        CryptoGCMWithKeysFromConfig(baseConfigKey)
+        CryptoGCMWithKeysFromConfig(baseConfigKey, () => fakeApplicationWithoutAnyKeys.configuration)
       }
     }
   }
@@ -148,7 +148,7 @@ class CryptoGCMWithKeysFromConfigSpec extends WordSpecLike with Matchers with Op
 
     "throw a SecurityException on construction" in running(fakeApplicationWithPreviousKeysOnly) {
       intercept[SecurityException]{
-        CryptoGCMWithKeysFromConfig(baseConfigKey)
+        CryptoGCMWithKeysFromConfig(baseConfigKey, () => fakeApplicationWithPreviousKeysOnly.configuration)
       }
     }
   }
@@ -190,38 +190,38 @@ class CryptoGCMWithKeysFromConfigSpec extends WordSpecLike with Matchers with Op
 
     "throw a SecurityException if the current key is too short" in running(fakeApplicationWithShortCurrentKey) {
       intercept[SecurityException]{
-        CryptoGCMWithKeysFromConfig(baseConfigKey)
+        CryptoGCMWithKeysFromConfig(baseConfigKey, () => fakeApplicationWithShortCurrentKey.configuration)
       }
     }
 
     "throw a SecurityException if the current key length is not 128 bits" in running(fakeApplicationWithInvalidKeySize) {
       intercept[SecurityException]{
-        CryptoGCMWithKeysFromConfig(baseConfigKey)
+        CryptoGCMWithKeysFromConfig(baseConfigKey, () => fakeApplicationWithInvalidKeySize.configuration)
       }
     }
 
 
     "throw a SecurityException if the first previous key is too short" in running(fakeApplicationWithShortFirstPreviousKey) {
       intercept[SecurityException]{
-        CryptoWithKeysFromConfig(baseConfigKey)
+        CryptoWithKeysFromConfig(baseConfigKey, () => fakeApplicationWithShortFirstPreviousKey.configuration)
       }
     }
 
     "throw a SecurityException if the first previous key cannot be base 64 decoded" in running(fakeApplicationWithInvalidBase64FirstPreviousKey) {
       intercept[SecurityException]{
-        CryptoWithKeysFromConfig(baseConfigKey)
+        CryptoWithKeysFromConfig(baseConfigKey, () => fakeApplicationWithInvalidBase64FirstPreviousKey.configuration)
       }
     }
 
     "throw a SecurityException if the other previous key is too short" in running(fakeApplicationWithShortOtherPreviousKey) {
       intercept[SecurityException]{
-        CryptoWithKeysFromConfig(baseConfigKey)
+        CryptoWithKeysFromConfig(baseConfigKey, () => fakeApplicationWithShortOtherPreviousKey.configuration)
       }
     }
 
     "throw a SecurityException if the other previous key cannot be base 64 decoded" in running(fakeApplicationWithInvalidBase64OtherPreviousKey) {
       intercept[SecurityException]{
-        CryptoWithKeysFromConfig(baseConfigKey)
+        CryptoWithKeysFromConfig(baseConfigKey, () => fakeApplicationWithInvalidBase64OtherPreviousKey.configuration)
       }
     }
 

--- a/src/test/scala/uk/gov/hmrc/crypto/CryptoWithKeysFromConfigSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/crypto/CryptoWithKeysFromConfigSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 HM Revenue & Customs
+ * Copyright 2017 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -60,7 +60,7 @@ class CryptoWithKeysFromConfigSpec extends WordSpecLike with Matchers with Optio
     ))
 
     "return a properly initialised, functional CompositeSymmetricCrypto object that works only with the current key" in running(fakeApplicationWithCurrentKeyOnly)  {
-      val crypto = CryptoWithKeysFromConfig(baseConfigKey)
+      val crypto = CryptoWithKeysFromConfig(baseConfigKey, () => fakeApplicationWithCurrentKeyOnly.configuration)
       crypto.encrypt(CurrentKey.plainMessage) shouldBe CurrentKey.encryptedMessage
       crypto.decrypt(CurrentKey.encryptedMessage) shouldBe CurrentKey.plainMessage
 
@@ -83,7 +83,7 @@ class CryptoWithKeysFromConfigSpec extends WordSpecLike with Matchers with Optio
     )
 
     "return a properly initialised, functional CompositeSymmetricCrypto object that works only with the current key" in running(fakeApplicationWithEmptyPreviousKeys)  {
-      val crypto = CryptoWithKeysFromConfig(baseConfigKey)
+      val crypto = CryptoWithKeysFromConfig(baseConfigKey, () => fakeApplicationWithEmptyPreviousKeys.configuration)
       crypto.encrypt(CurrentKey.plainMessage) shouldBe CurrentKey.encryptedMessage
       crypto.decrypt(CurrentKey.encryptedMessage) shouldBe CurrentKey.plainMessage
 
@@ -107,7 +107,7 @@ class CryptoWithKeysFromConfigSpec extends WordSpecLike with Matchers with Optio
     )
 
     "allows decrypting payloads that were encrypted using previous keys" in running(fakeApplicationWithCurrentAndPreviousKeys)  {
-      val crypto = CryptoWithKeysFromConfig(baseConfigKey)
+      val crypto = CryptoWithKeysFromConfig(baseConfigKey, () => fakeApplicationWithCurrentAndPreviousKeys.configuration)
 
       val previousKey1Crypto = CompositeSymmetricCrypto.aes(PreviousKey1.encryptionKey, Seq.empty)
       val encryptedWithPreviousKey1 = crypto.encrypt(PreviousKey1.plainMessage, previousKey1Crypto)
@@ -130,7 +130,7 @@ class CryptoWithKeysFromConfigSpec extends WordSpecLike with Matchers with Optio
 
     "throw a SecurityException on construction" in running(fakeApplicationWithoutAnyKeys) {
       intercept[SecurityException]{
-        CryptoWithKeysFromConfig(baseConfigKey)
+        CryptoWithKeysFromConfig(baseConfigKey, () => fakeApplicationWithoutAnyKeys.configuration)
       }
     }
   }
@@ -143,7 +143,7 @@ class CryptoWithKeysFromConfigSpec extends WordSpecLike with Matchers with Optio
 
     "throw a SecurityException on construction" in running(fakeApplicationWithPreviousKeysOnly) {
       intercept[SecurityException]{
-        CryptoWithKeysFromConfig(baseConfigKey)
+        CryptoWithKeysFromConfig(baseConfigKey, () => fakeApplicationWithPreviousKeysOnly.configuration)
       }
     }
   }
@@ -185,37 +185,37 @@ class CryptoWithKeysFromConfigSpec extends WordSpecLike with Matchers with Optio
 
     "throw a SecurityException if the current key is too short" in running(fakeApplicationWithShortCurrentKey) {
       intercept[SecurityException]{
-        CryptoWithKeysFromConfig(baseConfigKey)
+        CryptoWithKeysFromConfig(baseConfigKey, () => fakeApplicationWithShortCurrentKey.configuration)
       }
     }
 
     "throw a SecurityException if the current key cannot be base 64 decoded" in running(fakeApplicationWithInvalidBase64CurrentKey) {
       intercept[SecurityException]{
-        CryptoWithKeysFromConfig(baseConfigKey)
+        CryptoWithKeysFromConfig(baseConfigKey, () => fakeApplicationWithInvalidBase64CurrentKey.configuration)
       }
     }
 
     "throw a SecurityException if the first previous key is too short" in running(fakeApplicationWithShortFirstPreviousKey) {
       intercept[SecurityException]{
-        CryptoWithKeysFromConfig(baseConfigKey)
+        CryptoWithKeysFromConfig(baseConfigKey, () => fakeApplicationWithShortFirstPreviousKey.configuration)
       }
     }
 
     "throw a SecurityException if the first previous key cannot be base 64 decoded" in running(fakeApplicationWithInvalidBase64FirstPreviousKey) {
       intercept[SecurityException]{
-        CryptoWithKeysFromConfig(baseConfigKey)
+        CryptoWithKeysFromConfig(baseConfigKey, () => fakeApplicationWithInvalidBase64FirstPreviousKey.configuration)
       }
     }
 
     "throw a SecurityException if the other previous key is too short" in running(fakeApplicationWithShortOtherPreviousKey) {
       intercept[SecurityException]{
-        CryptoWithKeysFromConfig(baseConfigKey)
+        CryptoWithKeysFromConfig(baseConfigKey, () => fakeApplicationWithShortOtherPreviousKey.configuration)
       }
     }
 
     "throw a SecurityException if the other previous key cannot be base 64 decoded" in running(fakeApplicationWithInvalidBase64OtherPreviousKey) {
       intercept[SecurityException]{
-        CryptoWithKeysFromConfig(baseConfigKey)
+        CryptoWithKeysFromConfig(baseConfigKey, () => fakeApplicationWithInvalidBase64OtherPreviousKey.configuration)
       }
     }
   }

--- a/src/test/scala/uk/gov/hmrc/crypto/OneWayCryptoFromConfigSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/crypto/OneWayCryptoFromConfigSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 HM Revenue & Customs
+ * Copyright 2017 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/crypto/OneWayCryptoFromConfigSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/crypto/OneWayCryptoFromConfigSpec.scala
@@ -48,6 +48,17 @@ class OneWayCryptoFromConfigSpec extends WordSpecLike with Matchers with OptionV
     }
   }
 
+  "A correctly constructed one way encrypter using new Play 2.5 DI" should {
+
+    "encrypt and verify a password" in running(fakeApplicationWithCurrentKey) {
+      implicit val configurationThunk = () => fakeApplicationWithCurrentKey.configuration
+      val cryptor = OneWayCryptoFromConfig(baseConfigKey)
+      val encrypted = cryptor.hash(PlainText("myPassword"))
+
+      cryptor.verify(PlainText("myPassword"), encrypted) should be (true)
+    }
+  }
+
   "Constructing a one way encrypter without current or previous keys" should {
 
     def fakeApplicationWithoutAnyKeys = FakeApplication()

--- a/src/test/scala/uk/gov/hmrc/crypto/RSAEncryptDecryptSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/crypto/RSAEncryptDecryptSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 HM Revenue & Customs
+ * Copyright 2017 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/crypto/Sha512CryptoSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/crypto/Sha512CryptoSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 HM Revenue & Customs
+ * Copyright 2017 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
As part of the migration to Play 2.5.x dependency injection was introduced.
Crypto library didn't support DI (was still using Play.current.configuration, which is now deprecated)

The work contained on this PR aims to introduce DI as part of the library, along with the old behaviour that could be removed in the - far -future.

The logic from `object ApplicationCrypto` has been extracted into a`trait` and an instance of the `class ApplicationCrypto` can be bound to it using DI, or used via a companion object

Case classes that this object was relying on have been changed to take an input parameter (function with no args to provide a Configuration, which can come from Play.current.configuration - old world - or from some config object injected via DI):
- `CryptoGCMWithKeysFromConfig`
- `CryptoWithKeysFromConfig `
- `OneWayCryptoFromConfig `