### PR TITLE
Proposal: Make Encrypter an AdEncrypter and Decrypter an AdDecrypter

### DIFF
--- a/crypto/src/main/scala/uk/gov/hmrc/crypto/AesCrypto.scala
+++ b/crypto/src/main/scala/uk/gov/hmrc/crypto/AesCrypto.scala
@@ -40,9 +40,15 @@ trait AesCrypto extends Encrypter with Decrypter {
       case PlainText(text)   => Crypted(encrypter.encrypt(text))
     }
 
+  override def encrypt(valueToEncrypt: String, associatedText: String): EncryptedValue =
+    EncryptedValue(encrypter.encrypt(valueToEncrypt), "")
+
   override def decrypt(encrypted: Crypted): PlainText =
     PlainText(decrypter.decrypt(encrypted.value))
 
   override def decryptAsBytes(encrypted: Crypted): PlainBytes =
     PlainBytes(decrypter.decryptAsBytes(encrypted.value))
+
+  override def decrypt(valueToDecrypt: EncryptedValue, associatedText: String): String =
+    decrypter.decrypt(valueToDecrypt.value)
 }

--- a/crypto/src/main/scala/uk/gov/hmrc/crypto/AesGCMCrypto.scala
+++ b/crypto/src/main/scala/uk/gov/hmrc/crypto/AesGCMCrypto.scala
@@ -49,6 +49,14 @@ trait AesGCMCrypto extends Encrypter with Decrypter {
     new String(Base64.getEncoder.encode(combined))
   }
 
+  override def encrypt(valueToEncrypt: String, associatedText: String): EncryptedValue = {
+    val encryptedValue = crypto.encrypt(valueToEncrypt.getBytes, associatedText.getBytes)
+    EncryptedValue(
+      value = new String(Base64.getEncoder.encode(encryptedValue.value)),
+      nonce = new String(Base64.getEncoder.encode(encryptedValue.nonce))
+    )
+  }
+
   override def decrypt(encrypted: Crypted): PlainText =
     PlainText(crypto.decrypt(toEncryptedValue(encrypted.value), emptyAssociatedData))
 
@@ -61,5 +69,14 @@ trait AesGCMCrypto extends Encrypter with Decrypter {
       nonce = encryptedBytes.take(nonceLength),
       value = encryptedBytes.drop(nonceLength)
     )
+  }
+
+  override def decrypt(valueToDecrypt: EncryptedValue, associatedText: String): String = {
+    val encryptedBytes =
+      EncryptedBytes(
+        value = Base64.getDecoder.decode(valueToDecrypt.value.getBytes),
+        nonce = Base64.getDecoder.decode(valueToDecrypt.nonce.getBytes)
+      )
+    crypto.decrypt(encryptedBytes, associatedText.getBytes)
   }
 }

--- a/crypto/src/main/scala/uk/gov/hmrc/crypto/CompositeSymmetricCrypto.scala
+++ b/crypto/src/main/scala/uk/gov/hmrc/crypto/CompositeSymmetricCrypto.scala
@@ -28,13 +28,19 @@ trait CompositeSymmetricCrypto extends Encrypter with Decrypter {
   override def encrypt(value: PlainContent): Crypted =
     encrypt(value, currentCrypto)
 
+  override def encrypt(valueToEncrypt: String, associatedText: String): EncryptedValue =
+    currentCrypto.encrypt(valueToEncrypt, associatedText)
+
   override def decrypt(scrambled: Crypted): PlainText =
     decrypt(d => Try(d.decrypt(scrambled)))
 
   override def decryptAsBytes(scrambled: Crypted): PlainBytes =
     decrypt(d => Try(d.decryptAsBytes(scrambled)))
 
-  private def decrypt[T <: PlainContent](tryDecryption: Decrypter => Try[T]): T = {
+  override def decrypt(valueToDecrypt: EncryptedValue, associatedText: String): String =
+    decrypt(d => Try(d.decrypt(valueToDecrypt, associatedText)))
+
+  private def decrypt[T](tryDecryption: Decrypter => Try[T]): T = {
     val decrypterStream = (currentCrypto +: previousCryptos).to(LazyList)
 
     val message =

--- a/crypto/src/main/scala/uk/gov/hmrc/crypto/SymmetricCryptoFactory.scala
+++ b/crypto/src/main/scala/uk/gov/hmrc/crypto/SymmetricCryptoFactory.scala
@@ -30,13 +30,19 @@ object SymmetricCryptoFactory {
       override def encrypt(value: PlainContent): Crypted =
         currentCrypto.encrypt(value)
 
+      override def encrypt(valueToEncrypt: String, associatedText: String): EncryptedValue =
+        currentCrypto.encrypt(valueToEncrypt, associatedText)
+
       override def decrypt(scrambled: Crypted): PlainText =
         decrypt(d => Try(d.decrypt(scrambled)))
 
       override def decryptAsBytes(scrambled: Crypted): PlainBytes =
         decrypt(d => Try(d.decryptAsBytes(scrambled)))
 
-      private def decrypt[T <: PlainContent](tryDecryption: Decrypter => Try[T]): T = {
+      override def decrypt(valueToDecrypt: EncryptedValue, associatedText: String): String =
+        decrypt(d => Try(d.decrypt(valueToDecrypt, associatedText)))
+
+      private def decrypt[T](tryDecryption: Decrypter => Try[T]): T = {
         val decrypterStream = (currentCrypto +: previousDecrypters).to(LazyList)
         decrypterStream
           .map(tryDecryption)

--- a/crypto/src/main/scala/uk/gov/hmrc/crypto/model.scala
+++ b/crypto/src/main/scala/uk/gov/hmrc/crypto/model.scala
@@ -19,11 +19,11 @@ package uk.gov.hmrc.crypto
 import java.util.Base64
 import java.time.Instant
 
-trait Encrypter {
+trait Encrypter extends AdEncrypter {
   def encrypt(plain: PlainContent): Crypted
 }
 
-trait Decrypter {
+trait Decrypter extends AdDecrypter {
   def decrypt(reversiblyEncrypted: Crypted): PlainText
 
   def decryptAsBytes(reversiblyEncrypted: Crypted): PlainBytes


### PR DESCRIPTION
This will allow teams to migrate from non-AD encryption methods to AD ones while continuing to use the methods of SymmetricCryptoFactory to create their crypto instances.

The non-AD encrypter/decrypter instances will simply ignore the `associatedText` when encrypting and decrypting.

The downside of this is that after migration, `Encrypter` and `Decrypter` could continue to be used wherever an `AdEncrypter` and `AdEncrypter` is required, enabling teams to effectively ignore `associatedText`.